### PR TITLE
Switching attachment encryption to use an interface so we can configure the encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ ClientBin
 Generated_Code #added for RIA/Silverlight projects
 *.walrus
 *.designer.cs
+vendor/
 
 # Android code gen.
 R.cs

--- a/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
+++ b/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Replication.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Replication\SSLGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Revision.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Store\ISymmetricKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)View.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Auth\Authorizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Auth\FacebookAuthorizer.cs" />

--- a/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
+++ b/src/Couchbase.Lite.Shared/Couchbase.Lite.Shared.projitems
@@ -17,7 +17,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Replication.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Replication\SSLGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Revision.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Store\ISymmetricKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)View.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Auth\Authorizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Auth\FacebookAuthorizer.cs" />
@@ -91,6 +90,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Store\ConflictResolutionStrategy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Store\ContentValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Store\Cursor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Store\ISymmetricKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Store\JsonCollator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Store\RevIdCollator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Store\SQLException.cs" />

--- a/src/Couchbase.Lite.Shared/Database.cs
+++ b/src/Couchbase.Lite.Shared/Database.cs
@@ -771,7 +771,7 @@ namespace Couchbase.Lite
         /// Change the encryption key used to secure this database
         /// </summary>
         /// <param name="newKey">The new key to use</param>
-        public void ChangeEncryptionKey(SymmetricKey newKey)
+        public void ChangeEncryptionKey(ISymmetricKey newKey)
         {
             if (!IsOpen) {
                 Log.W(TAG, "ChangeEncryptionKey called on closed database");

--- a/src/Couchbase.Lite.Shared/Database/ICouchStore.cs
+++ b/src/Couchbase.Lite.Shared/Database/ICouchStore.cs
@@ -119,7 +119,7 @@ namespace Couchbase.Lite.Store
         /// <summary>
         /// Registers the encryption key of the database file. Must be called before opening the db.
         /// </summary>
-        void SetEncryptionKey(SymmetricKey key);
+        void SetEncryptionKey(ISymmetricKey key);
 
         /// <summary>
         /// Called when the delegate changes its encryptionKey property. The storage should rewrite its
@@ -127,7 +127,7 @@ namespace Couchbase.Lite.Store
         /// </summary>
         /// <returns>The action used to change the encryption key.</returns>
         /// <param name="newKey">The new key to use</param>
-        AtomicAction ActionToChangeEncryptionKey(SymmetricKey newKey);
+        AtomicAction ActionToChangeEncryptionKey(ISymmetricKey newKey);
 
         #endregion
 

--- a/src/Couchbase.Lite.Shared/Manager.cs
+++ b/src/Couchbase.Lite.Shared/Manager.cs
@@ -974,7 +974,7 @@ namespace Couchbase.Lite
         internal DatabaseOptions DefaultOptionsFor(string dbName)
         {
             var options = new DatabaseOptions();
-            var encryptionKey = default(SymmetricKey);
+            var encryptionKey = default(ISymmetricKey);
             if (Shared.TryGetValue("encryptionKey", "", dbName, out encryptionKey)) {
                 options.EncryptionKey = encryptionKey;
             }

--- a/src/Couchbase.Lite.Shared/Manager/DatabaseOptions.cs
+++ b/src/Couchbase.Lite.Shared/Manager/DatabaseOptions.cs
@@ -70,7 +70,7 @@ namespace Couchbase.Lite
         /// will use this key, and the same key must be given every time it's opened.  The default, null, 
         /// means the database is not encrypted.
         /// </summary>
-        public SymmetricKey EncryptionKey { get; set; }
+        public ISymmetricKey EncryptionKey { get; set; }
 
         #endregion
 

--- a/src/Couchbase.Lite.Shared/Store/BlobStore.cs
+++ b/src/Couchbase.Lite.Shared/Store/BlobStore.cs
@@ -69,9 +69,9 @@ namespace Couchbase.Lite
 
         private readonly string _path;
 
-        public SymmetricKey EncryptionKey { get; private set; }
+        public ISymmetricKey EncryptionKey { get; private set; }
 
-        public BlobStore(string path, SymmetricKey encryptionKey)
+        public BlobStore(string path, ISymmetricKey encryptionKey)
         {
             if (path == null) {
                 throw new ArgumentNullException("path");
@@ -367,7 +367,7 @@ namespace Couchbase.Lite
             return tempDirectory;
         }
 
-        public AtomicAction ActionToChangeEncryptionKey(SymmetricKey newKey)
+        public AtomicAction ActionToChangeEncryptionKey(ISymmetricKey newKey)
         {
             var action = new AtomicAction();
 
@@ -447,7 +447,7 @@ namespace Couchbase.Lite
             return action;
         }
 
-        public void ChangeEncryptionKey(SymmetricKey newKey)
+        public void ChangeEncryptionKey(ISymmetricKey newKey)
         {
             ActionToChangeEncryptionKey(newKey).Run();
         }

--- a/src/Couchbase.Lite.Shared/Store/ForestDBCouchStore.cs
+++ b/src/Couchbase.Lite.Shared/Store/ForestDBCouchStore.cs
@@ -88,14 +88,14 @@ namespace Couchbase.Lite.Store
             new ConcurrentDictionary<int, IntPtr>();
 
         private C4DatabaseFlags _config;
-        private SymmetricKey _encryptionKey;
+        private ISymmetricKey _encryptionKey;
         private LruCache<string, ForestDBViewStore> _views = new LruCache<string, ForestDBViewStore>(100);
 
         #endregion
 
         #region Properties
 
-        public SymmetricKey EncryptionKey
+        public ISymmetricKey EncryptionKey
         {
             get {
                 return _encryptionKey;
@@ -492,12 +492,12 @@ namespace Couchbase.Lite.Store
             }
         }
 
-        public void SetEncryptionKey(SymmetricKey key)
+        public void SetEncryptionKey(ISymmetricKey key)
         {
             _encryptionKey = key;
         }
 
-        public AtomicAction ActionToChangeEncryptionKey(SymmetricKey newKey)
+        public AtomicAction ActionToChangeEncryptionKey(ISymmetricKey newKey)
         {
             var retVal = new AtomicAction(() =>
                 ForestDBBridge.Check(err => 

--- a/src/Couchbase.Lite.Shared/Store/ForestDBViewStore.cs
+++ b/src/Couchbase.Lite.Shared/Store/ForestDBViewStore.cs
@@ -160,7 +160,7 @@ namespace Couchbase.Lite.Store
             }
         }
 
-        public AtomicAction ActionToChangeEncryptionKey(SymmetricKey newKey)
+        public AtomicAction ActionToChangeEncryptionKey(ISymmetricKey newKey)
         {
             return new AtomicAction(() => {
                 ForestDBBridge.Check(err => 

--- a/src/Couchbase.Lite.Shared/Store/ISQLiteStorageEngine.cs
+++ b/src/Couchbase.Lite.Shared/Store/ISQLiteStorageEngine.cs
@@ -64,7 +64,7 @@ namespace Couchbase.Lite.Store
         /// <param name="readOnly">Whether or not this storage engine is readonly</param> 
         /// <param name="schema">The schema to use to create the database initially</param>
         /// <param name="encryptionKey">A key for encrypting the database</param>
-        bool Open(string path, bool readOnly, string schema, SymmetricKey encryptionKey);
+        bool Open(string path, bool readOnly, string schema, ISymmetricKey encryptionKey);
 
         /// <summary>
         /// Gets the user version of the database

--- a/src/Couchbase.Lite.Shared/Store/ISymmetricKey.cs
+++ b/src/Couchbase.Lite.Shared/Store/ISymmetricKey.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Security.Cryptography;
+
+namespace Couchbase.Lite.Store
+{
+    public interface ISymmetricKey
+    {
+        /// <summary>
+        /// The SymmetricKey's key data; can be used to reconstitute it.
+        /// </summary>
+        byte[] KeyData { get; }
+
+        /// <summary>
+        /// The key data encoded as hex.
+        /// </summary>
+        string HexData { get; }
+
+        /// <summary>
+        /// Encrypts a data blob.
+        /// The output consists of a 16-byte random initialization vector,
+        /// followed by PKCS7-padded ciphertext. 
+        /// </summary>
+        byte[] EncryptData(byte[] data);
+
+        /// <summary>
+        /// Decrypts data encoded by encryptData.
+        /// </summary>
+        byte[] DecryptData(byte[] encryptedData);
+
+        /// <summary>
+        /// Streaming decryption.
+        /// </summary>
+        Stream DecryptStream(Stream stream);
+
+        /// <summary>
+        /// Creates a strem that will encrypt the given base stream
+        /// </summary>
+        /// <returns>The stream to write to for encryption</returns>
+        /// <param name="baseStream">The stream to read from</param>
+        CryptoStream CreateStream(Stream baseStream);
+
+        void Dispose();
+    }
+}

--- a/src/Couchbase.Lite.Shared/Store/ISymmetricKey.cs
+++ b/src/Couchbase.Lite.Shared/Store/ISymmetricKey.cs
@@ -32,10 +32,10 @@ namespace Couchbase.Lite.Store
         Stream DecryptStream(Stream stream);
 
         /// <summary>
-        /// Creates a strem that will encrypt the given base stream
+        /// Creates a stream that will encrypt the given base stream
         /// </summary>
         /// <returns>The stream to write to for encryption</returns>
-        /// <param name="baseStream">The stream to read from</param>
+        /// <param name="baseStream">The stream to read</param>
         Stream CreateStream(Stream baseStream);
     }
 }

--- a/src/Couchbase.Lite.Shared/Store/ISymmetricKey.cs
+++ b/src/Couchbase.Lite.Shared/Store/ISymmetricKey.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Security.Cryptography;
 
 namespace Couchbase.Lite.Store
 {
@@ -37,8 +36,6 @@ namespace Couchbase.Lite.Store
         /// </summary>
         /// <returns>The stream to write to for encryption</returns>
         /// <param name="baseStream">The stream to read from</param>
-        CryptoStream CreateStream(Stream baseStream);
-
-        void Dispose();
+        Stream CreateStream(Stream baseStream);
     }
 }

--- a/src/Couchbase.Lite.Shared/Store/SqliteCouchStore.cs
+++ b/src/Couchbase.Lite.Shared/Store/SqliteCouchStore.cs
@@ -102,7 +102,7 @@ namespace Couchbase.Lite.Store
         private string _directory;
         private int _transactionCount;
         private LruCache<string, object> _docIDs = new LruCache<string, object>(DOC_ID_CACHE_SIZE);
-        private SymmetricKey _encryptionKey;
+        private ISymmetricKey _encryptionKey;
         private bool _readOnly;
 
         #endregion
@@ -974,12 +974,12 @@ namespace Couchbase.Lite.Store
             return status;
         }
 
-        public void SetEncryptionKey(SymmetricKey key)
+        public void SetEncryptionKey(ISymmetricKey key)
         {
             _encryptionKey = key;
         }
 
-        public AtomicAction ActionToChangeEncryptionKey(SymmetricKey newKey)
+        public AtomicAction ActionToChangeEncryptionKey(ISymmetricKey newKey)
         {
             // https://www.zetetic.net/sqlcipher/sqlcipher-api/index.html#sqlcipher_export
             var hasRealEncryption = false;

--- a/src/Couchbase.Lite.Shared/Store/SqlitePclRawStorageEngine.cs
+++ b/src/Couchbase.Lite.Shared/Store/SqlitePclRawStorageEngine.cs
@@ -90,7 +90,7 @@ namespace Couchbase.Lite
         public int LastErrorCode { get; private set; }
 
         // Returns true on success, false if encryption key is wrong, throws exception for other cases
-        public bool Decrypt(SymmetricKey encryptionKey, sqlite3 connection)
+        public bool Decrypt(ISymmetricKey encryptionKey, sqlite3 connection)
         {
             var hasRealEncryption = false;
             try {
@@ -132,7 +132,7 @@ namespace Couchbase.Lite
             return true;
         }
 
-        public bool Open(String path, bool readOnly, string schema, SymmetricKey encryptionKey)
+        public bool Open(String path, bool readOnly, string schema, ISymmetricKey encryptionKey)
         {
             if (IsOpen)
                 return true;
@@ -173,7 +173,7 @@ namespace Couchbase.Lite
             return true;
         }
 
-        void OpenSqliteConnection(int flags, SymmetricKey encryptionKey, out sqlite3 db)
+        void OpenSqliteConnection(int flags, ISymmetricKey encryptionKey, out sqlite3 db)
         {
             LastErrorCode = raw.sqlite3_open_v2(Path, out db, flags, null);
             if (LastErrorCode != raw.SQLITE_OK) {

--- a/src/Couchbase.Lite.Shared/Store/SymmetricKey.cs
+++ b/src/Couchbase.Lite.Shared/Store/SymmetricKey.cs
@@ -251,7 +251,7 @@ namespace Couchbase.Lite.Store
         /// </summary>
         /// <returns>The stream to write to for encryption</returns>
         /// <param name="baseStream">The stream to read from</param>
-        public CryptoStream CreateStream(Stream baseStream)
+        public Stream CreateStream(Stream baseStream)
         {
             if (_cryptor == null || baseStream == null) {
                 return null;

--- a/src/Couchbase.Lite.Shared/Store/SymmetricKey.cs
+++ b/src/Couchbase.Lite.Shared/Store/SymmetricKey.cs
@@ -42,9 +42,9 @@ namespace Couchbase.Lite.Store
     /// <summary>
     /// Basic AES encryption. Uses a 256-bit (32-byte) key.
     /// </summary>
-    public sealed class SymmetricKey 
+    public sealed class SymmetricKey : ISymmetricKey
     #if !NET_3_5
-        : IDisposable
+        , IDisposable
     #endif
     {
 


### PR DESCRIPTION
This PR introduces the ISymmetricKey interface which referenced when encrypting and decrypting attachments. With this in place, we can then introduce a new implementation that uses AES in CTR mode so we can seek encrypted files. This is needed to support video playback of encrypted attachments

The existing tests continue to pass with these changes,
