### PR TITLE
Append the build number to the nuget package

### DIFF
--- a/packaging/nuget/couchbase-lite-apx.nuspec
+++ b/packaging/nuget/couchbase-lite-apx.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Couchbase.Lite</id>
     <title>Couchbase Lite</title>
-    <version>1.2.0.4-apx</version>
+    <version>1.2.0.4</version>
     <authors>Jim Borden, Zachary Gramana</authors>
     <owners>Couchbase</owners>
     <licenseUrl>https://github.com/couchbase/couchbase-lite-net/blob/master/LICENSE</licenseUrl>

--- a/script/build.fsx
+++ b/script/build.fsx
@@ -72,11 +72,17 @@ Target "Package" (fun _ ->
     ensureDirectory artifactsNuGetDir
     ensureDirectory artifactsBuildDir
     
+    let nuspecProps = getNuspecProperties(File.ReadAllText(nuspecPath))
+    
+    let version = match TeamCityBuildNumber.IsSome with
+                      | true ->  sprintf "%s-apx+%s" nuspecProps.Version TeamCityBuildNumber.Value
+                      | false -> sprintf "%s-apx" nuspecProps.Version
+    
     let basePath =  Path.GetFullPath "."
     // create and execute the command ourselves, since the NuGet helper doesn't allow us to set the BasePath command argument which we need
-    let commandArgs = sprintf @"pack -BasePath %s -Verbosity detailed -OutputDirectory %s %s" basePath artifactsNuGetDir nuspecPath
-    let result = Shell.Exec(nugetPath,  commandArgs)
-    
+    let commandArgs = sprintf @"pack -Verbosity detailed -BasePath %s -Version %s -OutputDirectory %s %s" basePath version artifactsNuGetDir nuspecPath
+    let result = Shell.Exec(nugetPath,  commandArgs.ToString())
+
     if result <> 0 then failwithf "%s exited with error %d" "build.bat" result
 )
 

--- a/script/build.fsx
+++ b/script/build.fsx
@@ -75,7 +75,7 @@ Target "Package" (fun _ ->
     let nuspecProps = getNuspecProperties(File.ReadAllText(nuspecPath))
     
     let version = match TeamCityBuildNumber.IsSome with
-                      | true ->  sprintf "%s.%s-apx" nuspecProps.Version TeamCityBuildNumber.Value
+                      | true ->  sprintf "%s%s-apx" nuspecProps.Version TeamCityBuildNumber.Value
                       | false -> sprintf "%s-apx" nuspecProps.Version
     
     let basePath =  Path.GetFullPath "."

--- a/script/build.fsx
+++ b/script/build.fsx
@@ -75,7 +75,7 @@ Target "Package" (fun _ ->
     let nuspecProps = getNuspecProperties(File.ReadAllText(nuspecPath))
     
     let version = match TeamCityBuildNumber.IsSome with
-                      | true ->  sprintf "%s-apx+%s" nuspecProps.Version TeamCityBuildNumber.Value
+                      | true ->  sprintf "%s.%s-apx" nuspecProps.Version TeamCityBuildNumber.Value
                       | false -> sprintf "%s-apx" nuspecProps.Version
     
     let basePath =  Path.GetFullPath "."

--- a/script/build.fsx
+++ b/script/build.fsx
@@ -73,10 +73,12 @@ Target "Package" (fun _ ->
     ensureDirectory artifactsBuildDir
     
     let nuspecProps = getNuspecProperties(File.ReadAllText(nuspecPath))
-    
-    let version = match TeamCityBuildNumber.IsSome with
-                      | true ->  sprintf "%s%s-apx" nuspecProps.Version TeamCityBuildNumber.Value
-                      | false -> sprintf "%s-apx" nuspecProps.Version
+        
+    let tcBuildValue = match TeamCityBuildNumber with
+                       | Some(num) -> num
+                       | None -> ""
+
+    let version = sprintf "%s%s-apx" nuspecProps.Version tcBuildValue
     
     let basePath =  Path.GetFullPath "."
     // create and execute the command ourselves, since the NuGet helper doesn't allow us to set the BasePath command argument which we need


### PR DESCRIPTION
When packaged on TeamCity, the build number will be appended as the last part of the package's version number.
