### PR TITLE
Replicators cannot be restarted 

### DIFF
--- a/packaging/nuget/couchbase-lite-apx.nuspec
+++ b/packaging/nuget/couchbase-lite-apx.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Couchbase.Lite</id>
     <title>Couchbase Lite</title>
-    <version>1.2.0.4</version>
+    <version>1.2.0.5</version>
     <authors>Jim Borden, Zachary Gramana</authors>
     <owners>Couchbase</owners>
     <licenseUrl>https://github.com/couchbase/couchbase-lite-net/blob/master/LICENSE</licenseUrl>

--- a/src/Couchbase.Lite.Shared/Replication.cs
+++ b/src/Couchbase.Lite.Shared/Replication.cs
@@ -761,6 +761,13 @@ namespace Couchbase.Lite
         public void Restart()
         {
             Changed += WaitForStopped;
+            if (Status == ReplicationStatus.Stopped) {
+                Log.W(TAG, "Restart() called on already stopped replication, simply calling Start()");
+                Changed -= WaitForStopped;
+                Start();
+                return;
+            }
+
             Stop();
         }
 
@@ -1155,6 +1162,7 @@ namespace Couchbase.Lite
                 return; // This logic has already been handled by DatabaseClosing()
             }
 
+            LocalDatabase.ForgetReplication(this);
             lastSequenceChanged = true; // force save the sequence
             SaveLastSequence (() => 
             {
@@ -1162,8 +1170,6 @@ namespace Couchbase.Lite
                 if (reachabilityManager != null) {
                     reachabilityManager.StatusChanged -= NetworkStatusChanged;
                 }
-
-                LocalDatabase.ForgetReplication(this);
             });
         }
 

--- a/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
+++ b/src/Couchbase.Lite.Tests.Shared/ReplicationTest.cs
@@ -253,12 +253,12 @@ namespace Couchbase.Lite
             using (var remoteDb = _sg.CreateDatabase(TempDbName())) {
                 CreateDocuments(database, 10);
                 var pusher = database.CreatePushReplication(remoteDb.RemoteUri);
+                pusher.Start();
+                pusher.Restart();
                 RunReplication(pusher);
-
-                Sleep(1000);
-
                 CreateDocuments(database, 10);
                 RunReplication(pusher);
+
                 Assert.AreEqual(20, pusher.CompletedChangesCount);
                 Assert.AreEqual(20, pusher.ChangesCount);
                 Assert.IsNull(pusher.LastError);


### PR DESCRIPTION
Pulling in the commit to fix for #542 Replicators cannot be restarted.  This allows us to use the optimized first sync and the restart in continuous mode to skip the deletions. 
